### PR TITLE
Refactor : "Redis port번호 수정"

### DIFF
--- a/src/main/java/com/TTT/TTT/Common/configs/RedisConfig.java
+++ b/src/main/java/com/TTT/TTT/Common/configs/RedisConfig.java
@@ -23,7 +23,7 @@ public class RedisConfig {
         RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
         configuration.setHostName(host); //레디스 서버의 호스트 이름
         configuration.setPort(port); //레디스 서버의 포트 번호
-        configuration.setDatabase(1); //레디스에 사용할 데이터베이스 인덱스(수업에 0번 데이터베이스를 이용하여 데이터 겹칠 것 같아 1번 사용했습니다)
+        configuration.setDatabase(0); //레디스에 사용할 데이터베이스 인덱스(수업에 0번 데이터베이스를 이용하여 데이터 겹칠 것 같아 1번 사용했습니다)
         return new LettuceConnectionFactory(configuration); //위에서 설정한 configuration을 기반으로 레디스에 연결할 객체
         }
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,7 +16,7 @@ spring :
     show_sql: true
   redis:
     host: localhost
-    port: 6379
+    port: 6380
 logging:
   level:
     root: info


### PR DESCRIPTION
port번호 6380으로 수정
각자 로컬에서 새로 도커추가 필요함.
docker run -d --name ttt-redis -p 6380:6379 redis
(ttt-redis는 변경해서 사용해도 무방)
RedisConfig쪽 이제 겹치지 않으니 setDatabase(0)으로 변경
테스트 결과 로그인 잘되고 레디스 0번에도 잘 들어감.