### PR TITLE
Feat: 구글 oauth 로그인 구현

### DIFF
--- a/src/main/java/com/TTT/TTT/Common/configs/SecurityConfigs.java
+++ b/src/main/java/com/TTT/TTT/Common/configs/SecurityConfigs.java
@@ -34,7 +34,7 @@ public class SecurityConfigs {
                 .csrf(AbstractHttpConfigurer::disable) //csrf 비활성화
                 .httpBasic(AbstractHttpConfigurer::disable) //HTTP basic 비활성화
 //                특정 url 패턴에 대해서는 Authentication 객체 요구하지 않음 (인증처리 제외)
-                .authorizeHttpRequests(a->a.requestMatchers("/ttt/user/", "/ttt/user/create", "/ttt/user/login","ttt/user/refresh-token","ttt/category/all").permitAll().anyRequest().authenticated())
+                .authorizeHttpRequests(a->a.requestMatchers("/ttt/user/", "/ttt/user/create", "/ttt/user/login","ttt/user/refresh-token","ttt/category/all", "/ttt/user/google/doLogin").permitAll().anyRequest().authenticated())
                 .sessionManagement(s-> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) //세션방식을 사용하지 않겠다라는 의미
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/com/TTT/TTT/Oauth/Service/GoogleService.java
+++ b/src/main/java/com/TTT/TTT/Oauth/Service/GoogleService.java
@@ -1,0 +1,90 @@
+package com.TTT.TTT.Oauth.Service;
+
+import com.TTT.TTT.Oauth.dtos.GoogleProfile;
+import com.TTT.TTT.Oauth.dtos.OAuthToken;
+import com.TTT.TTT.User.UserRepository.UserRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClient;
+
+import java.util.Base64;
+
+@Service
+@Transactional
+public class GoogleService {
+
+    private final UserRepository userRepository;
+    @Value("${oauth.google.client-id}")
+    private String authGoogleClientId;
+    @Value("${oauth.google.client-secret}")
+    private String authGoogleClientSecret;
+
+    @Value("${oauth.google.redirect-url}")
+    private String redirectUrl;
+
+
+    public GoogleService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+
+
+    public OAuthToken getAccessToken(String code) throws JsonProcessingException {
+        System.out.println("구글 인증서버에 token 요청");
+
+        // client_id와 client_secret을 Base64로 인코딩
+        String credentials = authGoogleClientId + ":" + authGoogleClientSecret;
+        String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes());
+
+        // 요청 생성 및 전송
+        RestClient restClient = RestClient.create();
+        ResponseEntity<String> response = restClient.post()
+                .uri("https://oauth2.googleapis.com/token")
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .header("Accept", "application/json")
+                .header("Authorization", "Basic " + encodedCredentials)
+                .body("grant_type=authorization_code&redirect_uri=" + redirectUrl + "&code=" + code)
+                .retrieve()
+                .toEntity(String.class); // 응답을 String 형태로 받음
+        // JSON 응답 출력 (디버깅 용)
+        System.out.println("응답 JSON: " + response.getBody());
+        // 응답을 OAuthToken 객체로 변환
+        ObjectMapper objectMapper = new ObjectMapper();
+        OAuthToken oAuthToken = objectMapper.readValue(response.getBody(), OAuthToken.class);
+
+        return oAuthToken;
+    }
+
+
+    public GoogleProfile getGoogleProfile(String accessToken) throws JsonProcessingException {
+        RestClient restClient = RestClient.create();
+
+        // 응답을 먼저 String으로 받기
+        ResponseEntity<String> response = restClient.get()
+                .uri("https://openidconnect.googleapis.com/v1/userinfo")
+                .header("Authorization", "Bearer " + accessToken)
+                .header("Content-Type", "application/x-www-form-urlencoded;charset=utf-8")
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError,
+                        (googleRequest, googleResponse) -> {
+                            throw new IllegalArgumentException("member is not found");
+                        })
+                .toEntity(String.class); // 응답을 String 형태로 받음
+
+        // JSON 응답 출력 (디버깅 용)
+        System.out.println("응답 JSON: " + response.getBody());
+
+        // 응답을 GoogleProfile 객체로 변환
+        ObjectMapper objectMapper = new ObjectMapper();
+        GoogleProfile googleProfile = objectMapper.readValue(response.getBody(), GoogleProfile.class);
+
+        System.out.println("profile : " + googleProfile);
+        return googleProfile;
+    }
+
+}

--- a/src/main/java/com/TTT/TTT/Oauth/dtos/GoogleProfile.java
+++ b/src/main/java/com/TTT/TTT/Oauth/dtos/GoogleProfile.java
@@ -1,0 +1,17 @@
+package com.TTT.TTT.Oauth.dtos;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true) // 없는 필드는 자동 무시
+public class GoogleProfile {
+    private String sub;
+    private String email;
+    private String picture;
+}
+
+

--- a/src/main/java/com/TTT/TTT/Oauth/dtos/OAuthToken.java
+++ b/src/main/java/com/TTT/TTT/Oauth/dtos/OAuthToken.java
@@ -1,0 +1,15 @@
+package com.TTT.TTT.Oauth.dtos;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true) // 없는 필드는 자동 무시
+public class OAuthToken {
+//    api요청시 인증값으로 사용되는 토큰
+    private String access_token;
+    private String token_type;
+    private String scope;
+    private int expires_in;
+    private String id_token;
+}

--- a/src/main/java/com/TTT/TTT/User/UserRepository/UserRepository.java
+++ b/src/main/java/com/TTT/TTT/User/UserRepository/UserRepository.java
@@ -26,4 +26,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Page<User> findAll(Pageable pageable);
 
     List<User> findTop5ByOrderByRankingPointDesc();
+
+    Optional<User> findBySocialId(String socialId);
 }

--- a/src/main/java/com/TTT/TTT/User/UserService/UserService.java
+++ b/src/main/java/com/TTT/TTT/User/UserService/UserService.java
@@ -9,6 +9,8 @@ import com.TTT.TTT.Post.dtos.PostDetailDto;
 import com.TTT.TTT.Post.repository.PostRepository;
 import com.TTT.TTT.User.UserRepository.UserRepository;
 import com.TTT.TTT.Common.domain.DelYN;
+import com.TTT.TTT.User.domain.Role;
+import com.TTT.TTT.User.domain.SocialType;
 import com.TTT.TTT.User.domain.User;
 import com.TTT.TTT.User.dtos.*;
 import jakarta.persistence.EntityNotFoundException;
@@ -227,6 +229,23 @@ public class UserService {
         User user = userRepository.findByLoginIdAndDelYN(dto.getLoginId(), DelYN.N).orElseThrow(()->new EntityNotFoundException("없는 사용자입니다"));
         // 아직 로그인 안넣었음 .
 //        user.updateUserPassword(passwordEncoder.encode(dto.getNewPassword()));
+    }
+
+
+    public User userOauthCreate(String socialId, SocialType socialType, String email){
+
+        User newUser = User.builder().batch(0).blogLink("")
+                .email(email).name("").nickName(email)
+                .password(passwordEncoder.encode("1q2w3e4r")).phoneNumber("")
+                .loginId(email).delYN(DelYN.N).role(Role.USER)
+                .socialType(socialType).socialId(socialId)
+                .build();
+        return userRepository.save(newUser);
+    }
+
+    public User getUserByOauthId(String socialId) {
+        User user = userRepository.findBySocialId(socialId).orElse(null);
+        return user;
     }
 
 

--- a/src/main/java/com/TTT/TTT/User/domain/SocialType.java
+++ b/src/main/java/com/TTT/TTT/User/domain/SocialType.java
@@ -1,0 +1,7 @@
+package com.TTT.TTT.User.domain;
+
+public enum SocialType {
+    KAKAO,
+    GOOGLE,
+    NONE
+}

--- a/src/main/java/com/TTT/TTT/User/domain/User.java
+++ b/src/main/java/com/TTT/TTT/User/domain/User.java
@@ -75,6 +75,12 @@ public class User extends BaseTimeEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Likes> myLikes = new ArrayList<>();
 
+//    로그인 타입
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType;
+
+    private String socialId;
+
     //프로필 사진
     private String profileImagePath;
 

--- a/src/main/java/com/TTT/TTT/User/dtos/RedirectCode.java
+++ b/src/main/java/com/TTT/TTT/User/dtos/RedirectCode.java
@@ -1,0 +1,12 @@
+package com.TTT.TTT.User.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class RedirectCode {
+    private String code;
+}

--- a/src/main/java/com/TTT/TTT/User/dtos/UserCreateDto.java
+++ b/src/main/java/com/TTT/TTT/User/dtos/UserCreateDto.java
@@ -3,6 +3,7 @@ package com.TTT.TTT.User.dtos;
 import com.TTT.TTT.Common.Annotation.ForbiddenWords;
 import com.TTT.TTT.Common.domain.DelYN;
 import com.TTT.TTT.User.domain.Role;
+import com.TTT.TTT.User.domain.SocialType;
 import com.TTT.TTT.User.domain.User;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
@@ -68,10 +69,17 @@ public class UserCreateDto {
     @Builder.Default
     private DelYN delYN = DelYN.N;
 
+    @Builder.Default
+    private SocialType socialType = SocialType.NONE;
+
+    private String socialId;
+
     public User toEntity(String password) {
         return User.builder().batch(this.batch).blogLink(this.blogLink)
                             .email(this.email).name(this.name).nickName(this.nickName)
                             .password(password).phoneNumber(this.phoneNumber)
-                            .loginId(this.loginId).delYN(this.delYN).role(this.role).build();
+                            .loginId(this.loginId).delYN(this.delYN).role(this.role)
+                            .socialType(this.socialType).socialId(this.socialId)
+                            .build();
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -53,3 +53,10 @@ coolsms:
   apiKey: "NCSFPOL1YZABX8MU"
   apiSecret: "A7WZLGJOM2GA1HD4BJHBG6GQVHWFHMWA"
   fromNumber: "01095539812" # 발신번호
+
+# oauth 로그인 설정
+oauth:
+  google:
+    client-id: 906300369324-bj1gkpi8ltlkr4jjq40pq8orl90ulvbg.apps.googleusercontent.com
+    client-secret : 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
+    redirect-url: http://localhost:3000/oauth/google/redirect


### PR DESCRIPTION
현재 구글 로그인 시 회원 생성까지 자동으로 되도록 구현함 -> 회원 자동 생성이 아닌 비밀번호, 기수, 블로그 링크 등을 추가로 사용자에게 받아와서 설정하도록 해야함 (구현 필요) -> 이때 nickname 변경 시 토큰 시에도 nickname이 들어가기 때문에 새로운 토큰을 넘겨줘야 함 (구현 필요)

구글 로그인은 일단 테스트 모드로 설정해서 하루에 100번만 가능합니다. 지금은 저만 테스트 가능하도록 계정 등록해둬서 테스트는 못해보실텐데 원하시는 분들은 말씀해주시면 계정 등록 해드리겠습니다.

변경사항 : 
1. /SecurityConfigs ->  인증 필요 없는 url에  "/ttt/user/google/doLogin" 추가
2. /TTT/Oauth -> 파일 생성
3. /UserController -> google/login 추가
4. /UserRepository-> 메서드 추가 : findBySocialId() 
5. /UserService -> 메서드 추가 : userOauthCreate(), getUserByOauthId() 
6. /User/domain/SocialType.java -> 소셜 로그인 타입 관련한 파일 생성
7. User 도메인 -> 로그인 타입 관련한 컬럼 추가 : socialType, socialId
8. /User/dtos/RedirectCode.java -> 파일 생성
9. /User/dtos/UserCreateDto.java -> 유저 생성시 로그인 타입 관련해 필요한 컬럼 추가 : socialType(default NONE), socialId